### PR TITLE
Added a database name env-var

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -27,8 +27,13 @@ func GetConnection() (bool, error) {
 	userid := os.Getenv("DATABASE_USERNAME")
 	password := os.Getenv("DATABASE_PASSWORD")
 	server := os.Getenv("DATABASE_SERVER")
+	database := os.Getenv("DATABASE_NAME")
 
 	dsn := "server=" + server + ";user id=" + userid + ";password=" + password
+
+	if len(database) != 0 {
+		dsn += ";database=" + database
+	}
 
 	connection, err := sql.Open("mssql", dsn)
 	if err != nil {


### PR DESCRIPTION
Using the `DATABASE_NAME` environment variable to set a default database on the connection.

If the variable is not set, it will connect to the master database using the default connection